### PR TITLE
bug fix in get_ctags

### DIFF
--- a/R/tag-data-ctags.R
+++ b/R/tag-data-ctags.R
@@ -104,6 +104,9 @@ get_ctags <- function (d = "R", has_tabs) {
     }
 
     tags <- tags [which (!grepl (excluded_file_ptn (), tags$file)), ]
+    if (nrow (tags) == 0L) {
+        return (NULL)
+    }
 
     tags$start <- as.integer (gsub ("^line\\:", "", tags$start))
 


### PR DESCRIPTION
Can't merge yet because code just  prior to this was submitted as v0.0.5 to CRAN. This can be merged once that has hopefully been accepted and bundled as release here.

# TODO Once merged:

- [ ] ~~Revert Dockerfile on server from remote install of this branch back to default/main~~
- [ ] Revert  `remotes` dependency in DESCRIPTION file of {pkgcheck}
- [ ] Revert  `remotes` dependency in DESCRIPTION file of {roreviewapi}