### PR TITLE
Fixing `ctags_install()` failure due to unused argument `fileext`

### DIFF
--- a/R/ctags-install.R
+++ b/R/ctags-install.R
@@ -45,7 +45,7 @@ ctags_make <- function (ctags_dir, bin_dir = NULL, sudo = TRUE) {
         stop ("A value for 'bin_dir' must be specified when 'sudo = FALSE'")
     }
 
-    f <- fs::file_temp (pattern = "ctags-make-", fileext = ".txt")
+    f <- fs::file_temp (pattern = "ctags-make-", ext = ".txt")
 
     confargs <- NULL
     if (!is.null (bin_dir)) {


### PR DESCRIPTION
Replaces `fileext` with `ext` in ctags-install.R.

`fs::temp_file()` expects `ext`.

Successfully install ctags.

Closes #74 