### PR TITLE
Draft fix for windows install issues

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pkgstats
 Title: Metrics of R Packages
-Version: 0.2.0.058
+Version: 0.2.0.059
 Authors@R: 
     person("Mark", "Padgham", , "mark.padgham@email.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2172-5265"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pkgstats
 Title: Metrics of R Packages
-Version: 0.2.0.059
+Version: 0.2.0.060
 Authors@R: 
     c(person("Mark", "Padgham", , "mark.padgham@email.com", role = c("aut", "cre"),
              comment = c(ORCID = "0000-0003-2172-5265")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,12 @@ Package: pkgstats
 Title: Metrics of R Packages
 Version: 0.2.0.059
 Authors@R: 
-    person("Mark", "Padgham", , "mark.padgham@email.com", role = c("aut", "cre"),
-           comment = c(ORCID = "0000-0003-2172-5265"))
+    c(person("Mark", "Padgham", , "mark.padgham@email.com", role = c("aut", "cre"),
+             comment = c(ORCID = "0000-0003-2172-5265")),
+      person("Michael", "Sumner", role = c("ctb"), 
+             comment = c(ORCID = "0000-0002-2471-7511")),       
+      person("Jeffrey", "Hollister", role = c("ctb"), 
+             comment = c(ORCID = "0000-0002-9254-9740")))
 Description: Static code analyses for R packages using the external code-tagging
     libraries 'ctags' and 'gtags'. Static analyses enable packages to be
     analysed very quickly, generally a couple of seconds at most. The package

--- a/R/ctags-install.R
+++ b/R/ctags-install.R
@@ -91,29 +91,89 @@ ctags_make <- function (ctags_dir, bin_dir = NULL, sudo = TRUE) {
 #' }
 #' @export
 ctags_install <- function (bin_dir = NULL, sudo = TRUE) {
-
-    if (!.Platform$OS.type == "unix") {
-        return (NULL)
+    
+    pkg_path <- system.file(package = "pkgstats")
+    pkg_path <- gsub("/inst", "", pkg_path)
+    
+    os <- Sys.info () ["sysname"]
+    
+    if (os == "Darwin") {
+        install_ctags_macos(pkg_path)
+    } 
+    
+    if (os == "Windows") {
+        install_ctags_windows(pkg_path)
     }
-
+    
+    if (.Platform$OS.type == "unix" & os != "Darwin") {
+        ctags_dir <- clone_ctags (destdir = tempdir ())
+        ctags_make (ctags_dir, bin_dir, sudo)
+    
+        if (!has_gtags ()) {
+            gtags_install (sudo = sudo)
+        }
+    
+        if (!sudo) {
+            # system ("hash -d ctags")
+            system ("hash ctags")
+            system ("hash gtags")
+        }
+    }
+    
     if (tryCatch (ctags_test (),
-        error = function (e) FALSE
+                  error = function (e) FALSE
     )) {
-        # already installed and okay
-        return (NULL)
+      # already installed and okay
+      message("ctags installed and passed test.")
+      return (NULL)
     }
+}
 
-    ctags_dir <- clone_ctags (destdir = tempdir ())
-    ctags_make (ctags_dir, bin_dir, sudo)
+install_ctags_macos <- function (pkg_path) {
+  
+  ctags_dir <- fs::path (pkg_path, "inst", "bin")
+  if (!fs::dir_exists (ctags_dir)) {
+    fs::dir_create (ctags_dir, recurse = TRUE)
+  }
+  ctags_path <- fs::path (ctags_dir, "ctags")
+  if (!file.exists (ctags_path)) {
+    u <- "https://autobrew.github.io/archive/high_sierra/universal-ctags-p5.9.20210530.0.tar.xz" # nolint
+    f <- basename (u)
+    utils::download.file (u, f, quiet = TRUE)
+    utils::untar (f, extras = "--strip-components=1", exdir = ctags_dir)
+    fs::file_delete (f)
+  }
+}
 
-    if (!has_gtags ()) {
-        gtags_install (sudo = sudo)
-    }
+get_ctags_path_win <- function(pkg_path){
+  u <- "https://github.com/rwinlib/universal-ctags/archive/refs/tags/v5.9.20210530.0.zip" # nolint
+  ctags_path <- normalizePath (fs::path (
+    pkg_path,
+    "windows",
+    paste0 (
+      "universal-ctags-",
+      tools::file_path_sans_ext (gsub ("^v", "", basename (u)))
+    ),
+    "bin"
+  ), mustWork = FALSE)
+  ctags_path
+}
 
-    if (!sudo) {
-        # system ("hash -d ctags")
-        system ("hash ctags")
-        system ("hash gtags")
-    }
+install_ctags_windows <- function (pkg_path) {
+  u <- "https://github.com/rwinlib/universal-ctags/archive/refs/tags/v5.9.20210530.0.zip" # nolint
+  ctags_path <- get_ctags_path_win(pkg_path)
+  ctag_win_path <- fs::path_abs (fs::path (pkg_path, "windows"))
+  if (!fs::dir_exists (ctag_win_path)) {
+    fs::dir_create (ctag_win_path, recurse = TRUE)
+  }
+  if (!fs::file_exists (ctags_path)) {
+    f <- tempfile(fileext = "pkgstats_ctags_lib.zip")
+    utils::download.file (u, f, quiet = TRUE)
+    utils::unzip (f, exdir = ctags_path, junkpaths = TRUE)
+    fs::file_delete (f)
+  }
+  if(!grepl("universal-ctags-5.9.20210530.0", Sys.getenv("PATH"))){
+    Sys.setenv(PATH = paste0(Sys.getenv("PATH"), ";", ctags_path))
+  }
 }
 # nocov end

--- a/R/ctags-test.R
+++ b/R/ctags-test.R
@@ -143,7 +143,18 @@ ctags_test <- function (quiet = TRUE) {
 }
 
 has_ctags <- function () {
-
+  
+    os <- Sys.info () ["sysname"]
+    
+    if (os == "Windows") {
+      pkg_path <- system.file(package = "pkgstats")
+      pkg_path <- gsub("/inst", "", pkg_path)
+      ctags_path <- get_ctags_path_win(pkg_path)
+      if(!grepl("universal-ctags-5.9.20210530.0", Sys.getenv("PATH"))){
+        Sys.setenv(PATH = paste0(Sys.getenv("PATH"), ";", ctags_path))
+      }
+    }
+  
     ctags_path <- dirname (Sys.which ("ctags"))
     nzchar (ctags_path)
 }

--- a/R/ctags-test.R
+++ b/R/ctags-test.R
@@ -120,7 +120,7 @@ ctags_test <- function (quiet = TRUE) {
 
         fs::file_delete (td)
     }
-    #browser()
+    
     check <- ctags_check & gtags_check
 
     if (!check) {

--- a/R/ctags-test.R
+++ b/R/ctags-test.R
@@ -14,7 +14,6 @@
 #' }
 #' @export
 ctags_test <- function (quiet = TRUE) {
-
     if (!has_ctags ()) {
         stop ("No ctags installation found.", call. = FALSE)
     }
@@ -91,10 +90,12 @@ ctags_test <- function (quiet = TRUE) {
     }
 
     td <- fs::path (fs::path_temp (), "pkgstats-gtags-test")
+    
     if (fs::dir_exists (td)) {
         gtags_check <- TRUE
     } else {
         f <- system.file ("extdata", "pkgstats_9.9.tar.gz", package = "pkgstats")
+        
         pkgstats_path <- extract_tarball (f)
         if (fs::dir_exists (td)) {
             fs::dir_delete (td)
@@ -105,8 +106,13 @@ ctags_test <- function (quiet = TRUE) {
         fs::dir_create (td, recurse = TRUE)
         chk <- fs::dir_copy (pkgstats_path, td)
         # unlink (pkgstats_path, recursive = TRUE) # done in unload
-        cmd <- "export GTAGS_LABEL=new-ctags; gtags"
-        gtags_test <- withr::with_dir (fs::path (td, "pkgstats"), system (cmd, intern = TRUE))
+        if (.Platform$OS.type == "windows"){
+          cmd <- "set GTAGS_LABEL=new-ctags; gtags"
+          gtags_test <- withr::with_dir (fs::path (td, "pkgstats"), shell (cmd, intern = TRUE))
+        } else {
+          cmd <- "export GTAGS_LABEL=new-ctags; gtags"
+          gtags_test <- withr::with_dir (fs::path (td, "pkgstats"), system (cmd, intern = TRUE))
+        }
         gtags_check <- length (gtags_test) == 0L
         if (!gtags_check) {
             gtags_check <- any (grepl ("error", gtags_test, ignore.case = TRUE))
@@ -114,7 +120,7 @@ ctags_test <- function (quiet = TRUE) {
 
         fs::file_delete (td)
     }
-
+    #browser()
     check <- ctags_check & gtags_check
 
     if (!check) {

--- a/R/ctags-test.R
+++ b/R/ctags-test.R
@@ -144,17 +144,6 @@ ctags_test <- function (quiet = TRUE) {
 
 has_ctags <- function () {
   
-    os <- Sys.info () ["sysname"]
-    
-    if (os == "Windows") {
-      pkg_path <- system.file(package = "pkgstats")
-      pkg_path <- gsub("/inst", "", pkg_path)
-      ctags_path <- get_ctags_path_win(pkg_path)
-      if(!grepl("universal-ctags-5.9.20210530.0", Sys.getenv("PATH"))){
-        Sys.setenv(PATH = paste0(Sys.getenv("PATH"), ";", ctags_path))
-      }
-    }
-  
     ctags_path <- dirname (Sys.which ("ctags"))
     nzchar (ctags_path)
 }

--- a/R/gtags-install.R
+++ b/R/gtags-install.R
@@ -1,17 +1,6 @@
 # nocov start
 has_gtags <- function () {
     
-    os <- Sys.info () ["sysname"]
-    
-    if (os == "Windows") {
-      pkg_path <- system.file(package = "pkgstats")
-      pkg_path <- gsub("/inst", "", pkg_path)
-      ctags_path <- get_ctags_path_win(pkg_path)
-      if(!grepl("universal-ctags-5.9.20210530.0", Sys.getenv("PATH"))){
-        Sys.setenv(PATH = paste0(Sys.getenv("PATH"), ";", ctags_path))
-      }
-    }
-    
     gtags_path <- dirname (Sys.which ("gtags"))
     nzchar (gtags_path)
 }

--- a/R/gtags-install.R
+++ b/R/gtags-install.R
@@ -1,6 +1,17 @@
 # nocov start
 has_gtags <- function () {
-
+    
+    os <- Sys.info () ["sysname"]
+    
+    if (os == "Windows") {
+      pkg_path <- system.file(package = "pkgstats")
+      pkg_path <- gsub("/inst", "", pkg_path)
+      ctags_path <- get_ctags_path_win(pkg_path)
+      if(!grepl("universal-ctags-5.9.20210530.0", Sys.getenv("PATH"))){
+        Sys.setenv(PATH = paste0(Sys.getenv("PATH"), ";", ctags_path))
+      }
+    }
+    
     gtags_path <- dirname (Sys.which ("gtags"))
     nzchar (gtags_path)
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -75,7 +75,7 @@ install_ctags_windows <- function (pkg_path) {
     }
     if (!fs::file_exists (ctags_path)) {
         f <- "lib.zip"
-        utils::download.file (u, f, quiet = TRUE)
+        utils::download.file (u, f, quiet = TRUE, mode = "wb")
         utils::unzip (f, exdir = ctag_win_path)
         fs::file_delete (f)
     }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -32,4 +32,18 @@
     }
 }
 
+.onLoad <- function(libname, pkgname) {
+  
+  os <- Sys.info () ["sysname"]
+  
+  if (os == "Windows") {
+    pkg_path <- system.file(package = "pkgstats")
+    pkg_path <- gsub("/inst", "", pkg_path)
+    ctags_path <- get_ctags_path_win(pkg_path)
+    if(!grepl("universal-ctags-5.9.20210530.0", Sys.getenv("PATH"))){
+      Sys.setenv(PATH = paste0(Sys.getenv("PATH"), ";", ctags_path))
+    }
+  }
+  
+}
 # nocov end

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -17,67 +17,19 @@
         packageStartupMessage (
             "https://github.com/autobrew/archive/tree/master/high_sierra"
         )
-        chk <- readline ("Do you agree (y/n)?")
-        if (substring (tolower (chk), 1, 1) == "y") {
-            install_ctags_macos (pkg_path)
-        }
+        packageStartupMessage (
+            "Run pkgstats::ctags_install() to install universal-ctags."
+        )
     } else if (os == "Windows") {
         packageStartupMessage (
             "This package requires downloading and installing ",
             "binary 'universal-ctags' software from:"
         )
         packageStartupMessage ("https://github.com/rwinlib/universal-ctags/")
-        chk <- readline ("Do you agree (y/n)?")
-        if (substring (tolower (chk), 1, 1) == "y") {
-            install_ctags_windows (pkg_path)
-        }
-        ctags_path <- get_ctags_path(pkg_path)
-        Sys.setenv(PATH = paste0(Sys.getenv("PATH"), ";", ctags_path))
+        packageStartupMessage (
+          "Run pkgstats::ctags_install() to install universal-ctags."
+        )
     }
 }
 
-install_ctags_macos <- function (pkg_path) {
-
-    ctags_dir <- fs::path (pkg_path, "inst", "bin")
-    if (!fs::dir_exists (ctags_dir)) {
-        fs::dir_create (ctags_dir, recurse = TRUE)
-    }
-    ctags_path <- fs::path (ctags_dir, "ctags")
-    if (!file.exists (ctags_path)) {
-        u <- "https://autobrew.github.io/archive/high_sierra/universal-ctags-p5.9.20210530.0.tar.xz" # nolint
-        f <- basename (u)
-        utils::download.file (u, f, quiet = TRUE)
-        utils::untar (f, extras = "--strip-components=1", exdir = ctags_dir)
-        fs::file_delete (f)
-    }
-}
-
-get_ctags_path <- function(pkg_path){
-  u <- "https://github.com/rwinlib/universal-ctags/archive/refs/tags/v5.9.20210530.0.zip" # nolint
-  ctags_path <- normalizePath (fs::path (
-    pkg_path,
-    "windows",
-    paste0 (
-      "universal-ctags-",
-      tools::file_path_sans_ext (gsub ("^v", "", basename (u)))
-    ),
-    "bin"
-  ), mustWork = FALSE)
-  ctags_path
-}
-
-install_ctags_windows <- function (pkg_path) {
-    u <- "https://github.com/rwinlib/universal-ctags/archive/refs/tags/v5.9.20210530.0.zip" # nolint
-    ctags_path <- get_ctags_path(pkg_path)
-    ctag_win_path <- fs::path_abs (fs::path (pkg_path, "windows"))
-    if (!fs::dir_exists (ctag_win_path)) {
-        fs::dir_create (ctag_win_path, recurse = TRUE)
-    }
-    if (!fs::file_exists (ctags_path)) {
-        f <- "lib.zip"
-        utils::download.file (u, f, quiet = TRUE, mode = "wb")
-        utils::unzip (f, exdir = ctag_win_path)
-        fs::file_delete (f)
-    }
-}
 # nocov end

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -31,6 +31,8 @@
         if (substring (tolower (chk), 1, 1) == "y") {
             install_ctags_windows (pkg_path)
         }
+        ctags_path <- get_ctags_path(pkg_path)
+        Sys.setenv(PATH = paste0(Sys.getenv("PATH"), ";", ctags_path))
     }
 }
 
@@ -50,17 +52,23 @@ install_ctags_macos <- function (pkg_path) {
     }
 }
 
+get_ctags_path <- function(pkg_path){
+  u <- "https://github.com/rwinlib/universal-ctags/archive/refs/tags/v5.9.20210530.0.zip" # nolint
+  ctags_path <- normalizePath (fs::path (
+    pkg_path,
+    "windows",
+    paste0 (
+      "universal-ctags-",
+      tools::file_path_sans_ext (gsub ("^v", "", basename (u)))
+    ),
+    "bin"
+  ), mustWork = FALSE)
+  ctags_path
+}
+
 install_ctags_windows <- function (pkg_path) {
     u <- "https://github.com/rwinlib/universal-ctags/archive/refs/tags/v5.9.20210530.0.zip" # nolint
-    ctags_path <- normalizePath (fs::path (
-        pkg_path,
-        "windows",
-        paste0 (
-            "universal-ctags-",
-            tools::file_path_sans_ext (gsub ("^v", "", basename (u)))
-        ),
-        "bin"
-    ), mustWork = FALSE)
+    ctags_path <- get_ctags_path(pkg_path)
     ctag_win_path <- fs::path_abs (fs::path (pkg_path, "windows"))
     if (!fs::dir_exists (ctag_win_path)) {
         fs::dir_create (ctag_win_path, recurse = TRUE)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -60,14 +60,15 @@ install_ctags_windows <- function (pkg_path) {
             tools::file_path_sans_ext (gsub ("^v", "", basename (u)))
         ),
         "bin"
-    ))
-    if (!fs::dir_exists ("windows")) {
-        fs::dir_create ("windows", recurse = TRUE)
+    ), mustWork = FALSE)
+    ctag_win_path <- fs::path_abs (fs::path (pkg_path, "windows"))
+    if (!fs::dir_exists (ctag_win_path)) {
+        fs::dir_create (ctag_win_path, recurse = TRUE)
     }
     if (!fs::file_exists (ctags_path)) {
         f <- "lib.zip"
         utils::download.file (u, f, quiet = TRUE)
-        utils::unzip (f, exdir = "windows")
+        utils::unzip (f, exdir = ctag_win_path)
         fs::file_delete (f)
     }
 }


### PR DESCRIPTION
This should address several issues.

First, windows ctags installs should now work.  Second, the ctag installation is moved into ctag_install and not done with .onAttach.  

Related to https://github.com/ropensci-review-tools/pkgstats/pull/79 and https://github.com/ropensci-review-tools/pkgstats/issues/65

ctags_install will need additional testing on linux and macos.

Plus startup messages are the same, regardless of availability of ctags.  Testing for that prior to message would be a good addition.