### PR TITLE
Fix dl_data fn

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # R specific hooks: https://github.com/lorenzwalthert/precommit
 repos:
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.4.3.9020
+    rev: v0.4.3.9023
     hooks:
     -   id: style-files
         args: [--style_pkg=spaceout, --style_fun=spaceout_style]

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pkgstats
 Title: Metrics of R Packages
-Version: 0.2.2.023
+Version: 0.2.2.024
 Authors@R: 
     c(person("Mark", "Padgham", , "mark.padgham@email.com", role = c("aut", "cre"),
              comment = c(ORCID = "0000-0003-2172-5265")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pkgstats
 Title: Metrics of R Packages
-Version: 0.2.2.022
+Version: 0.2.2.023
 Authors@R: 
     c(person("Mark", "Padgham", , "mark.padgham@email.com", role = c("aut", "cre"),
              comment = c(ORCID = "0000-0003-2172-5265")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 
 - Fix bug in source docline count when there are no doclines
 - Fix output of translations in summary fn
+- Fix bug in `dl_pkgstats_data()` - defaulted to latest release, but data are fixed for a previous release.
 
 0.2.2
 ===================

--- a/R/pkgstats-data-download.R
+++ b/R/pkgstats-data-download.R
@@ -15,12 +15,27 @@ dl_pkgstats_data <- function (current = TRUE,
     requireNamespace ("curl", quietly = TRUE)
     requireNamespace ("jsonlite", quietly = TRUE)
 
+    cran_data_version <- "v0.1.6"
+
+    # First get integer "release_id" of that version:
     u <- paste0 (
         "https://api.github.com/repos/",
         "ropensci-review-tools/pkgstats/",
-        "releases/latest"
+        "releases"
     )
+    res <- curl::curl_fetch_memory (u)
+    res <- jsonlite::fromJSON (rawToChar (res$content))
+    row_num <- match (cran_data_version, res$tag_name)
+    if (is.na (row_num)) {
+        stop (
+            "Release for CRAN data {cran_data_version} not found.",
+            call. = FALSE
+        )
+    }
+    release_id <- res$id [row_num]
 
+    # Then get that release:
+    u <- paste0 (u, "/", release_id)
     res <- curl::curl_fetch_memory (u)
     hdrs <- curl::parse_headers (res$headers)
     http_code <- as.integer (gsub (

--- a/codemeta.json
+++ b/codemeta.json
@@ -11,7 +11,7 @@
   "codeRepository": "https://github.com/ropensci-review-tools/pkgstats",
   "issueTracker": "https://github.com/ropensci-review-tools/pkgstats/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.2.2.022",
+  "version": "0.2.2.023",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",

--- a/codemeta.json
+++ b/codemeta.json
@@ -11,7 +11,7 @@
   "codeRepository": "https://github.com/ropensci-review-tools/pkgstats",
   "issueTracker": "https://github.com/ropensci-review-tools/pkgstats/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.2.2.023",
+  "version": "0.2.2.024",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",


### PR DESCRIPTION
It was pegged to latest release which broke with latest CRAN update because data are all fixed to a prior release. This PR fixes.