### PR TITLE
Return early if ctags cannot generate an output file

### DIFF
--- a/R/ctags-test.R
+++ b/R/ctags-test.R
@@ -58,7 +58,10 @@ ctags_test <- function (quiet = TRUE, noerror = FALSE) {
 
     f_out <- fs::file_temp (ext = ".txt")
     cmd <- paste0 ("ctags --sort=no --fields=+KZ -f ", f_out, " ", f_in)
-    system (cmd)
+    chk <- tryCatch (
+        system (cmd),
+        error = function (e) 127L
+    )
 
     if (!fs::file_exists (f_out)) {
       if (noerror) {

--- a/R/ctags-test.R
+++ b/R/ctags-test.R
@@ -63,7 +63,7 @@ ctags_test <- function (quiet = TRUE, noerror = FALSE) {
         error = function (e) 127L
     )
 
-    if (!fs::file_exists (f_out)) {
+    if (chk > 0L || !fs::file_exists (f_out)) {
       if (noerror) {
         message ("Existing ctags installation is incomplete")
         return (FALSE)

--- a/R/ctags-test.R
+++ b/R/ctags-test.R
@@ -60,6 +60,14 @@ ctags_test <- function (quiet = TRUE, noerror = FALSE) {
     cmd <- paste0 ("ctags --sort=no --fields=+KZ -f ", f_out, " ", f_in)
     system (cmd)
 
+    if (!fs::file_exists (f_out)) {
+      if (noerror) {
+        message ("Existing ctags installation is incomplete")
+        return (FALSE)
+      }
+      stop ("Existing ctags installation is incomplete")
+    }
+
     # remove header lines:
     x <- brio::read_lines (f_out)
     x <- x [-which (grepl ("^\\!", x))]


### PR DESCRIPTION
The `ctags` version shipped with `emacs` does not support the `--sort=no` option, hence it terminates without producing any output files. By checking this we can provide a better message to the user instead of failing when attempting to read an inexistent file.

The message reported is just an attempt, it could be better. In any case, this fixes #115.